### PR TITLE
Fix dtwm wrapper breaking X resources for children

### DIFF
--- a/script/dtwm
+++ b/script/dtwm
@@ -12,6 +12,6 @@ else
 	CONFIG=$PREFIX/share/opencde/dtwm/dtwmrc
 fi
 
-XFILESEARCHPATH=$PREFIX/share/opencde/app-defaults/Dtwm mwm -name Dtwm \
+XUSERFILESEARCHPATH=$PREFIX/share/opencde/app-defaults/Dtwm mwm -name Dtwm \
 -xrm "Dtwm*configFile: $CONFIG"
 


### PR DESCRIPTION
Change env variable which breaks X res support for children of dtwm.  Mainly affects dtrun, but also affects anything launched directly by dtwm/mwm
